### PR TITLE
Fixed repository reference

### DIFF
--- a/geotools/pom.xml
+++ b/geotools/pom.xml
@@ -14,9 +14,9 @@
 
   <repositories>
    <repository>
-     <id>osgeo</id>
-     <name>OSGeo Maven Repository</name>
-     <url>http://download.osgeo.org/webdav/geotools/</url>
+      <id>osgeo</id>
+      <name>OSGeo Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
    </repository>
   </repositories>
 


### PR DESCRIPTION
 * Got the new url from https://docs.geotools.org/latest/userguide/tutorial/quickstart/maven.html
 * `mvn compile test` now succeeds