### PR TITLE
Changed jeo-guava's parent to contrib

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>io.jeo</groupId>
-    <artifactId>util</artifactId>
+    <artifactId>contrib</artifactId>
     <version>0-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
All contrib modules except jeo-guava point to jeo-contrib as their parent. jeo-guava pointed to jeo-util instead. See #6 

